### PR TITLE
Add explicit wake lock to keep screen on

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An ultra simple, free meditation app for Android.
 - Simple and clean interface focused on meditation
 - Meditation timer with customizable duration (5, 10, 15, 20, 25, 30, or 40 minutes)
 - Meditation bell sounds at the start and end of sessions
-- Keeps screen active during meditation
+- Keeps screen active during meditation with wake lock
 - Minimal permissions required
 
 ## Download

--- a/app/src/main/java/com/patflynn/vibe/MainActivity.kt
+++ b/app/src/main/java/com/patflynn/vibe/MainActivity.kt
@@ -4,6 +4,7 @@ import android.media.MediaPlayer
 import android.os.Bundle
 import android.os.CountDownTimer
 import android.view.View
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import com.patflynn.vibe.databinding.ActivityMainBinding
 import java.util.concurrent.TimeUnit
@@ -23,6 +24,9 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        
+        // Ensure the screen stays on during the entire app lifecycle
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
         setupSlider()
         setupStartButton()


### PR DESCRIPTION
## Summary
- Add WindowManager FLAG_KEEP_SCREEN_ON flag to ensure screen stays on
- This enhances the existing AndroidManifest approach with a more reliable method
- Improves user experience during longer meditation sessions

## Test plan
- Open the app and start a meditation session
- Verify that the screen does not turn off during use