### PR TITLE
Add vibration feedback for meditation sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ An ultra simple, free meditation app for Android.
 
 - Simple and clean interface focused on meditation
 - Meditation timer with customizable duration (5, 10, 15, 20, 25, 30, or 40 minutes)
-- Meditation bell sounds at the start and end of sessions
+- Meditation bell sounds and gentle vibration at the start and end of sessions
 - Keeps screen active during meditation with wake lock
-- Minimal permissions required
+- Minimal permissions required (only vibration)
 
 ## Download
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.patflynn.vibe">
+    
+    <!-- Vibration permission -->
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/patflynn/vibe/MainActivity.kt
+++ b/app/src/main/java/com/patflynn/vibe/MainActivity.kt
@@ -1,8 +1,11 @@
 package com.patflynn.vibe
 
+import android.content.Context
 import android.media.MediaPlayer
 import android.os.Bundle
 import android.os.CountDownTimer
+import android.os.VibrationEffect
+import android.os.Vibrator
 import android.view.View
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
@@ -116,6 +119,14 @@ class MainActivity : AppCompatActivity() {
         // Create and prepare a new MediaPlayer
         mediaPlayer = MediaPlayer.create(this, R.raw.meditation_bell)
         mediaPlayer?.start()
+        
+        // Also vibrate the device gently
+        val vibrator = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        if (vibrator.hasVibrator()) {
+            // Create a gentle vibration pattern - 500ms vibration, 200ms pause, 500ms vibration
+            val vibrationPattern = longArrayOf(0, 500, 200, 500)
+            vibrator.vibrate(VibrationEffect.createWaveform(vibrationPattern, -1))
+        }
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## Summary
This PR adds gentle vibration feedback at the start and end of meditation sessions to enhance the user experience.

## Changes
- Add VIBRATE permission to AndroidManifest.xml
- Add gentle vibration pattern at start and end of meditation sessions
- Implement the vibration in the playBellSound method
- Update README to document the new feature

## Testing
1. Start a meditation session (tap play button)
2. Verify that the device vibrates in addition to playing the bell sound
3. Let the timer complete or tap to end session early
4. Verify that the device vibrates again when session ends

## Additional Notes
This feature provides tactile feedback to complement the audio feedback, which can be helpful for users in quiet environments or for those with hearing impairments.