### PR TITLE
Add elegant splash screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ An ultra simple, free meditation app for Android.
 
 ## Features
 
+- Elegant splash screen for a calming intro experience
 - Simple and clean interface focused on meditation
 - Meditation timer with customizable duration (5, 10, 15, 20, 25, 30, or 40 minutes)
 - Meditation bell sounds and gentle vibration at the start and end of sessions

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,15 +13,20 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Vibe">
         <activity
-            android:name=".MainActivity"
+            android:name=".SplashActivity"
             android:exported="true"
-            android:screenOrientation="portrait"
-            android:keepScreenOn="true"> <!-- Keeps screen on during meditation -->
+            android:theme="@style/SplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        
+        <activity
+            android:name=".MainActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"
+            android:keepScreenOn="true"/> <!-- Keeps screen on during meditation -->
     </application>
 
 </manifest>

--- a/app/src/main/java/com/patflynn/vibe/SplashActivity.kt
+++ b/app/src/main/java/com/patflynn/vibe/SplashActivity.kt
@@ -1,0 +1,27 @@
+package com.patflynn.vibe
+
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.appcompat.app.AppCompatActivity
+
+class SplashActivity : AppCompatActivity() {
+
+    private val SPLASH_DELAY = 1500L // 1.5 seconds
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        // No need to set a content view as the theme handles the display
+        
+        // Use a handler to delay loading the main activity
+        Handler(Looper.getMainLooper()).postDelayed({
+            // Start the main activity
+            startActivity(Intent(this, MainActivity::class.java))
+            
+            // Close the splash screen activity
+            finish()
+        }, SPLASH_DELAY)
+    }
+}

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Base application theme. -->
+    <style name="SplashTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:windowBackground">@color/primary</item>
+        <item name="android:statusBarColor">@color/primary_dark</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Summary
This PR adds a calming splash screen to enhance the app's initial user experience and reinforce the app's branding.

## Changes
- Create SplashActivity as the new entry point for the app
- Implement splash theme with primary color background
- Add 1.5-second delay before transitioning to the main meditation screen
- Update activity flow in AndroidManifest.xml
- Update README to document the new feature

## Testing
1. Install the APK on your device
2. Launch the app and verify the splash screen appears briefly
3. Confirm the splash screen transitions smoothly to the main meditation screen after 1.5 seconds

## Additional Notes
The splash screen uses a simple color background rather than an image to keep the app minimal and focused. This also helps with performance and app size considerations.