### PR TITLE
Fix Firebase Test Lab workflow by updating upload-artifact to v4

### DIFF
--- a/.github/workflows/firebase-test-lab.yml
+++ b/.github/workflows/firebase-test-lab.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: firebase-test-results
           path: firebase-test-results


### PR DESCRIPTION
## Summary
- Updates the actions/upload-artifact action from v3 to v4 in the Firebase Test Lab workflow
- Fixes the 'Missing download info for actions/upload-artifact@v3' error in GitHub Actions runs

## Test plan
- Run the Firebase Test Lab workflow to verify it can upload artifacts correctly