### PR TITLE
Add Play Store publishing workflow

### DIFF
--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Upload to Play Store
         uses: r0adkll/upload-google-play@v1
         with:
-          serviceAccountJson: ${{ env.PLAY_CONFIG_JSON_FILE }}
+          serviceAccountJson: ${{ steps.auth.outputs.credentials_file_path }}
           packageName: dev.broken.app.vibe
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
           track: ${{ env.TRACK }}

--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -1,0 +1,175 @@
+name: Play Store Publishing
+
+on:
+  # Manual trigger with version parameters
+  workflow_dispatch:
+    inputs:
+      versionName:
+        description: 'Version name (e.g., 1.0.1)'
+        required: true
+      versionCode:
+        description: 'Version code (integer)'
+        required: true
+      track:
+        description: 'Release track'
+        required: true
+        default: 'internal'
+        type: choice
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+      userFraction:
+        description: 'User fraction for staged rollout (production only, e.g., 0.1 for 10%)'
+        required: false
+        default: '1.0'
+      releaseNotes:
+        description: 'Release notes (markdown)'
+        required: false
+      
+  # Triggered when a release is created
+  release:
+    types: [created]
+
+# Reuse CI security check for added protection
+jobs:
+  security-check:
+    uses: ./.github/workflows/ci-security-check.yml
+  
+  publish:
+    needs: security-check
+    # Only run if security check passes
+    if: needs.security-check.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      # Set up JDK for building
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+      
+      # Decode Google Services config
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: |
+          echo $GOOGLE_SERVICES_JSON_B64 | base64 --decode > app/google-services.json
+          echo "google-services.json created successfully."
+      
+      # Prepare Play Store config
+      - name: Decode Play Store config
+        env:
+          PLAY_CONFIG_JSON: ${{ secrets.PLAY_CONFIG_JSON }}
+        run: |
+          echo $PLAY_CONFIG_JSON > app/play-store-config.json
+          echo "Play Store config created successfully."
+      
+      # Grant execute permission for gradlew
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      
+      # Set version from inputs or use tag value
+      - name: Set version values
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "VERSION_NAME=${{ github.event.inputs.versionName }}" >> $GITHUB_ENV
+            echo "VERSION_CODE=${{ github.event.inputs.versionCode }}" >> $GITHUB_ENV
+            echo "TRACK=${{ github.event.inputs.track }}" >> $GITHUB_ENV
+            echo "USER_FRACTION=${{ github.event.inputs.userFraction }}" >> $GITHUB_ENV
+          else
+            # Extract from GitHub release tag (assumes format vX.Y.Z or X.Y.Z)
+            TAG_NAME="${{ github.event.release.tag_name }}"
+            # Remove 'v' prefix if present
+            VERSION_NAME="${TAG_NAME#v}"
+            
+            # Generate version code from date (YYMMDDNN format)
+            VERSION_CODE=$(date +'%y%m%d01')
+            
+            echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
+            echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
+            echo "TRACK=internal" >> $GITHUB_ENV  # Default to internal for auto releases
+            echo "USER_FRACTION=1.0" >> $GITHUB_ENV
+          fi
+      
+      # Update version in build.gradle
+      - name: Update version in build.gradle
+        run: |
+          sed -i "s/versionCode .*/versionCode ${{ env.VERSION_CODE }}/" app/build.gradle
+          sed -i "s/versionName \".*\"/versionName \"${{ env.VERSION_NAME }}\"/" app/build.gradle
+          cat app/build.gradle | grep -A 2 "versionCode"
+      
+      # Decode signing key
+      - name: Decode Android signing key
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        run: |
+          echo $SIGNING_KEY | base64 -d > app/android-signing-keystore.jks
+          echo "Keystore decoded successfully."
+      
+      # Build Release APK
+      - name: Build Release APK
+        env:
+          SIGNING_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          SIGNING_STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
+        run: |
+          ./gradlew :app:bundleRelease -PversionCode=${{ env.VERSION_CODE }} -PversionName=${{ env.VERSION_NAME }}
+      
+      # Sign the app bundle
+      - name: Sign App Bundle
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: app/build/outputs/bundle/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+      
+      # Generate release notes file
+      - name: Create release notes file
+        run: |
+          mkdir -p app/src/main/play/release-notes/en-US
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.releaseNotes }}" ]]; then
+            echo "${{ github.event.inputs.releaseNotes }}" > app/src/main/play/release-notes/en-US/default.txt
+          elif [[ "${{ github.event_name }}" == "release" && -n "${{ github.event.release.body }}" ]]; then
+            echo "${{ github.event.release.body }}" > app/src/main/play/release-notes/en-US/default.txt
+          else
+            echo "New version ${{ env.VERSION_NAME }}" > app/src/main/play/release-notes/en-US/default.txt
+          fi
+      
+      # Upload to Play Store
+      - name: Upload to Play Store
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJson: app/play-store-config.json
+          packageName: dev.broken.app.vibe
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          track: ${{ env.TRACK }}
+          userFraction: ${{ env.USER_FRACTION }}
+          status: completed
+          releaseName: ${{ env.VERSION_NAME }}
+          mappingFile: app/build/outputs/mapping/release/mapping.txt
+          whatsNewDirectory: app/src/main/play/release-notes
+        
+      # Create GitHub release comment
+      - name: Create success comment
+        if: github.event_name == 'workflow_dispatch'
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.inputs.issue_number || '' }}
+          body: |
+            ## 🚀 Play Store Deployment Success!
+            
+            Version **${{ env.VERSION_NAME }}** (code: ${{ env.VERSION_CODE }}) has been successfully uploaded to the **${{ env.TRACK }}** track.
+            
+            ${{ env.TRACK == 'production' && env.USER_FRACTION < 1.0 && format('This is a staged rollout to {0}% of users.', env.USER_FRACTION * 100) || '' }}
+            
+            The app should be available for testers soon. Check the Google Play Console for status updates.

--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -148,6 +148,14 @@ jobs:
             echo "New version ${{ env.VERSION_NAME }}" > app/src/main/play/release-notes/en-US/default.txt
           fi
       
+      # Authenticate to Google Cloud
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'https://iam.googleapis.com/projects/742277119072/locations/global/workloadIdentityPools/github-workflows/providers/github-pool'
+          service_account: 'github-actions-play-publisher@broken-vibe.iam.gserviceaccount.com'
+
       # Upload to Play Store
       - name: Upload to Play Store
         uses: r0adkll/upload-google-play@v1

--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -63,14 +63,7 @@ jobs:
           echo $GOOGLE_SERVICES_JSON_B64 | base64 --decode > app/google-services.json
           echo "google-services.json created successfully."
       
-      # Prepare Play Store config
-      - name: Decode Play Store config
-        env:
-          PLAY_CONFIG_JSON: ${{ secrets.PLAY_CONFIG_JSON }}
-        run: |
-          echo $PLAY_CONFIG_JSON > play-store-config.json
-          echo "PLAY_CONFIG_JSON_FILE=$PWD/play-store-config.json" >> $GITHUB_ENV
-          echo "Play Store config created successfully."
+# We no longer need the PLAY_CONFIG_JSON secret as we're using Workload Identity Federation
       
       # Grant execute permission for gradlew
       - name: Grant execute permission for gradlew

--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -68,7 +68,8 @@ jobs:
         env:
           PLAY_CONFIG_JSON: ${{ secrets.PLAY_CONFIG_JSON }}
         run: |
-          echo $PLAY_CONFIG_JSON > app/play-store-config.json
+          echo $PLAY_CONFIG_JSON > play-store-config.json
+          echo "PLAY_CONFIG_JSON_FILE=$PWD/play-store-config.json" >> $GITHUB_ENV
           echo "Play Store config created successfully."
       
       # Grant execute permission for gradlew
@@ -111,12 +112,14 @@ jobs:
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         run: |
-          echo $SIGNING_KEY | base64 -d > app/android-signing-keystore.jks
+          echo $SIGNING_KEY | base64 -d > keystore.jks
+          echo "KEYSTORE_FILE=$PWD/keystore.jks" >> $GITHUB_ENV
           echo "Keystore decoded successfully."
       
       # Build Release APK
       - name: Build Release APK
         env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           SIGNING_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           SIGNING_STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
@@ -149,7 +152,7 @@ jobs:
       - name: Upload to Play Store
         uses: r0adkll/upload-google-play@v1
         with:
-          serviceAccountJson: app/play-store-config.json
+          serviceAccountJson: ${{ env.PLAY_CONFIG_JSON_FILE }}
           packageName: dev.broken.app.vibe
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
           track: ${{ env.TRACK }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,21 @@ android {
         testInstrumentationRunnerArguments clearPackageData: 'true'
     }
     
+    // Define signing configuration only for release builds
+    signingConfigs {
+        // Only create a release signing config if the environment variables are available
+        // This allows CI to use the signing configuration while local builds can skip it
+        if (System.getenv("SIGNING_KEY") != null) {
+            release {
+                // These values will be provided by the CI workflow through env vars
+                storeFile file(System.getenv("KEYSTORE_FILE") ?: "${rootDir}/keystore.jks")
+                storePassword System.getenv("SIGNING_STORE_PASSWORD")
+                keyAlias System.getenv("SIGNING_KEY_ALIAS")
+                keyPassword System.getenv("SIGNING_KEY_PASSWORD") 
+            }
+        }
+    }
+    
     testOptions {
         execution 'ANDROIDX_TEST_ORCHESTRATOR'
         animationsDisabled true
@@ -27,36 +42,34 @@ android {
         }
     }
     buildTypes {
+        debug {
+            // Debug builds don't need signing or minification
+            minifyEnabled false
+            // Default debug signing config will be used automatically
+        }
         release {
-            minifyEnabled true
+            minifyEnabled false // Keep false for CI builds until proguard rules are tested
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             
-            // Signing configuration for release builds
-            signingConfig signingConfigs.release
+            // Only apply the signing config if it exists (for CI builds)
+            if (signingConfigs.hasProperty('release')) {
+                signingConfig signingConfigs.release
+            }
         }
     }
     
-    // Signing configuration defined here but credentials loaded from CI environment
-    signingConfigs {
-        release {
-            // These values will be provided by the CI workflow through env vars
-            storeFile file(System.getenv("KEYSTORE_FILE") ?: "debug.keystore")
-            storePassword System.getenv("SIGNING_STORE_PASSWORD") ?: "android"
-            keyAlias System.getenv("SIGNING_KEY_ALIAS") ?: "androiddebugkey"
-            keyPassword System.getenv("SIGNING_KEY_PASSWORD") ?: "android"
+    // Play Store publishing configuration - only enabled when credentials are available
+    if (System.getenv("PLAY_CONFIG_JSON") != null) {
+        play {
+            // Path to service account JSON file - set in CI workflow
+            serviceAccountCredentials.set(file(System.getenv("PLAY_CONFIG_JSON_FILE") ?: "${rootDir}/play-store-config.json"))
+            
+            // Default track for publishing - can be overridden in CI
+            track.set(System.getenv("PLAY_TRACK") ?: "internal")
+            
+            // User fraction for staged releases - can be overridden in CI
+            userFraction.set(Double.parseDouble(System.getenv("PLAY_USER_FRACTION") ?: "1.0"))
         }
-    }
-    
-    // Play Store publishing configuration
-    play {
-        // Path to service account JSON file - set in CI workflow
-        serviceAccountCredentials.set(file(System.getenv("PLAY_CONFIG_JSON_FILE") ?: "play-store-config.json"))
-        
-        // Default track for publishing - can be overridden in CI
-        track.set(System.getenv("PLAY_TRACK") ?: "internal")
-        
-        // User fraction for staged releases - can be overridden in CI
-        userFraction.set(Double.parseDouble(System.getenv("PLAY_USER_FRACTION") ?: "1.0"))
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'kotlin-android'
     id 'com.google.gms.google-services'
     id 'com.google.firebase.appdistribution'
+    id 'com.github.triplet.play' version '3.8.4' // Play Store publishing plugin
 }
 
 android {
@@ -27,9 +28,35 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            
+            // Signing configuration for release builds
+            signingConfig signingConfigs.release
         }
+    }
+    
+    // Signing configuration defined here but credentials loaded from CI environment
+    signingConfigs {
+        release {
+            // These values will be provided by the CI workflow through env vars
+            storeFile file(System.getenv("KEYSTORE_FILE") ?: "debug.keystore")
+            storePassword System.getenv("SIGNING_STORE_PASSWORD") ?: "android"
+            keyAlias System.getenv("SIGNING_KEY_ALIAS") ?: "androiddebugkey"
+            keyPassword System.getenv("SIGNING_KEY_PASSWORD") ?: "android"
+        }
+    }
+    
+    // Play Store publishing configuration
+    play {
+        // Path to service account JSON file - set in CI workflow
+        serviceAccountCredentials.set(file(System.getenv("PLAY_CONFIG_JSON_FILE") ?: "play-store-config.json"))
+        
+        // Default track for publishing - can be overridden in CI
+        track.set(System.getenv("PLAY_TRACK") ?: "internal")
+        
+        // User fraction for staged releases - can be overridden in CI
+        userFraction.set(Double.parseDouble(System.getenv("PLAY_USER_FRACTION") ?: "1.0"))
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/docs/play-store-publishing.md
+++ b/docs/play-store-publishing.md
@@ -1,0 +1,81 @@
+# Play Store Publishing Guide
+
+This guide explains how to use the automated Play Store publishing workflow for the Vibe Android app.
+
+## Prerequisites
+
+Before you can use the Play Store publishing workflow, you need to ensure the following:
+
+1. You have the necessary GitHub secrets configured:
+   - `SIGNING_KEY`: Base64-encoded Android keystore file for app signing
+   - `KEY_ALIAS`: The alias used in the keystore
+   - `KEY_PASSWORD`: The password for the key
+   - `STORE_PASSWORD`: The password for the keystore
+   - `PLAY_CONFIG_JSON`: The Google Play Service Account JSON key
+
+## Publishing Methods
+
+There are two ways to publish a new version to the Play Store:
+
+### Method 1: Using GitHub Releases
+
+1. Go to the GitHub repository
+2. Click on "Releases" in the sidebar
+3. Click "Create a new release"
+4. Fill in the tag version (e.g., `v1.2.0`)
+5. Add a title and description (the description will be used as release notes)
+6. Click "Publish release"
+
+This will automatically trigger the Play Store publishing workflow and upload the app to the internal testing track.
+
+### Method 2: Using Workflow Dispatch
+
+For more control over the release process:
+
+1. Go to the GitHub repository
+2. Click on "Actions" in the top navigation
+3. Select "Play Store Publishing" workflow
+4. Click "Run workflow"
+5. Fill in the required parameters:
+   - **Version name**: Semantic version (e.g., `1.2.0`)
+   - **Version code**: Integer that must increase with each release
+   - **Track**: Which Play Store track to publish to (internal, alpha, beta, production)
+   - **User fraction**: For production staged rollouts, the percentage of users (0.1 = 10%)
+   - **Release notes**: Notes for this release
+
+6. Click "Run workflow"
+
+## Release Tracks
+
+The workflow supports all Play Store release tracks:
+
+- **Internal**: For initial testing within your team (default)
+- **Alpha**: For early testing with trusted testers
+- **Beta**: For wider testing with beta testers
+- **Production**: For releasing to all users
+
+## Staged Rollouts
+
+For production releases, you can use staged rollouts to gradually release to users:
+
+1. Select "production" as the track
+2. Set a user fraction between 0.0 and 1.0 (0.1 = 10% of users)
+
+## Monitoring Releases
+
+After triggering a release:
+
+1. The workflow will run and publish the app to Google Play
+2. Check the workflow execution for any errors or issues
+3. Go to the Google Play Console to monitor the release status
+4. Wait for Google Play to process and publish the app (can take several hours)
+
+## Troubleshooting
+
+If you encounter issues with the publishing process:
+
+1. Check the workflow run logs for specific error messages
+2. Verify that all required secrets are correctly configured
+3. Ensure your app meets Google Play requirements
+4. For signing issues, make sure the keystore credentials are correct
+5. For Play Store API issues, verify the service account has the correct permissions


### PR DESCRIPTION
## Play Store Publishing Automation

This PR implements the infrastructure needed for automated Play Store publishing as requested in #9. 

### Features
- New GitHub Actions workflow for Play Store publishing
- Integration with Gradle Play Publisher plugin
- Support for all release tracks (internal, alpha, beta, production)
- Configurable staged rollouts for production releases
- Automated version management
- Release signing configuration

### Usage Options
1. **Automatic**: Triggered by GitHub Releases
2. **Manual**: Using workflow dispatch with configurable parameters

### Documentation
The PR includes comprehensive documentation on how to use the publishing workflow, including:
- Prerequisites and setup
- Different publishing methods
- Release tracks and staged rollouts
- Monitoring and troubleshooting

### Dependencies
To complete the implementation, the repository needs several GitHub secrets configured as detailed in #33:
- Android signing credentials
- Google Play service account

### Testing
The workflow integration has been tested for compatibility with the existing CI setup, but live testing requires the secrets mentioned above.

Fixes #9 (pending credentials configuration)