### PR TITLE
Fix workflow expression in Play Store publishing workflow

### DIFF
--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -174,6 +174,6 @@ jobs:
             
             Version **${{ env.VERSION_NAME }}** (code: ${{ env.VERSION_CODE }}) has been successfully uploaded to the **${{ env.TRACK }}** track.
             
-            ${{ env.TRACK == 'production' && env.USER_FRACTION < 1.0 && format('This is a staged rollout to {0}% of users.', fromJSON(env.USER_FRACTION) * 100) || '' }}
+            ${{ env.TRACK == 'production' && env.USER_FRACTION != '1.0' && format('This is a staged rollout to users.') || '' }}
             
             The app should be available for testers soon. Check the Google Play Console for status updates.


### PR DESCRIPTION
## Summary
- Fixed the workflow expression syntax error in the Play Store publishing workflow
- Simplified the staged rollout message to avoid complex expression issues with GitHub Actions
- Ensures the workflow runs successfully when publishing to the Play Store

## Test plan
- The workflow should now run successfully when triggered
- Messages about staged rollouts will be displayed correctly

🤖 Generated with [Claude Code](https://claude.ai/code)