### PR TITLE
Fix workflow permissions for Google Cloud authentication

### DIFF
--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -42,6 +42,10 @@ jobs:
     # Only run if security check passes
     if: needs.security-check.outputs.should-run == 'true'
     runs-on: ubuntu-latest
+    # Required for OIDC authentication with Google Cloud
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Added required permissions for Google Cloud Workload Identity Federation
- Added 'id-token: write' permission which is needed for OIDC authentication
- Fixed the authentication error seen in the workflow run

## Test plan
- The workflow should now be able to authenticate with Google Cloud using Workload Identity Federation
- The 'auth' step should complete successfully without the previous authentication error

🤖 Generated with [Claude Code](https://claude.ai/code)