### PR TITLE
Fix Workload Identity Provider format for Google Cloud Auth

### DIFF
--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -150,7 +150,7 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v2'
         with:
-          workload_identity_provider: 'https://iam.googleapis.com/projects/742277119072/locations/global/workloadIdentityPools/github-workflows/providers/github-pool'
+          workload_identity_provider: 'projects/742277119072/locations/global/workloadIdentityPools/github-workflows/providers/github-pool'
           service_account: 'github-actions-play-publisher@broken-vibe.iam.gserviceaccount.com'
 
       # Upload to Play Store


### PR DESCRIPTION
## Summary
- Fixed the Workload Identity Provider format in the Play Store publishing workflow
- Removed the 'https://iam.googleapis.com/' prefix from the identity provider path
- This corrects the 'invalid audience' error during Google Cloud authentication

## Test plan
- The workflow should be able to authenticate with Google Cloud successfully
- The 'auth' step should complete without the previous error about invalid audience

🤖 Generated with [Claude Code](https://claude.ai/code)