### PR TITLE
Generate screenshots and video for README (Issue #46)

### DIFF
--- a/.github/workflows/update-readme-assets.yml
+++ b/.github/workflows/update-readme-assets.yml
@@ -1,0 +1,163 @@
+name: Update README Assets
+
+on:
+  # Run on pushes to main
+  push:
+    branches: [ main ]
+    paths:
+      - '**.kt'
+      - '**.xml'
+      - 'gradle/**'
+      - '**.gradle'
+  
+  # Run on workflow dispatch
+  workflow_dispatch:
+
+  # Run on a schedule (weekly)
+  schedule:
+    - cron: '0 0 * * 0'  # At 00:00 on Sunday
+
+jobs:
+  generate-assets:
+    runs-on: ubuntu-latest
+    
+    steps:
+      # Check out the repo
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      # Set up JDK
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+      
+      # Set up Android SDK
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        
+      # Grant execute permission for gradlew
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      
+      # Build debug APK
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+      
+      # Build test APK
+      - name: Build test APK
+        run: ./gradlew assembleDebugAndroidTest
+      
+      # Run screenshot tests on emulator
+      - name: Run tests on emulator
+        uses: ReactiveCircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          target: google_apis
+          arch: x86_64
+          profile: Nexus 6
+          script: |
+            # Grant storage permissions needed for screenshots
+            adb shell pm grant dev.broken.app.vibe android.permission.WRITE_EXTERNAL_STORAGE
+            adb shell pm grant dev.broken.app.vibe android.permission.READ_EXTERNAL_STORAGE
+            
+            # Run the screenshot tests
+            ./gradlew connectedCheck -Pandroid.testInstrumentationRunnerArguments.class=dev.broken.app.vibe.screenshots.*
+            
+            # Pull the screenshots from the device
+            mkdir -p screenshots
+            adb pull /sdcard/Pictures/screenshots/ ./screenshots/
+            
+            # Pull the screen recordings
+            mkdir -p recordings
+            adb pull /sdcard/Movies/screenshots/ ./recordings/
+      
+      # Process the screenshots and videos
+      - name: Process assets
+        run: |
+          # Create assets directory in the repo
+          mkdir -p assets/screenshots
+          mkdir -p assets/videos
+          
+          # Copy the latest screenshots and optimize them
+          find ./screenshots -name "*.png" -type f -exec cp {} ./assets/screenshots/ \;
+          
+          # Copy the latest video 
+          find ./recordings -name "*.mp4" -type f -exec cp {} ./assets/videos/ \;
+          
+          # Convert main video to GIF for the README
+          sudo apt-get update && sudo apt-get install -y ffmpeg
+          LATEST_VIDEO=$(find ./assets/videos -type f -name "*.mp4" | sort -r | head -n 1)
+          if [ -n "$LATEST_VIDEO" ]; then
+            ffmpeg -i "$LATEST_VIDEO" -vf "fps=10,scale=320:-1:flags=lanczos" ./assets/videos/app_demo.gif
+          fi
+      
+      # Update the README with the new assets
+      - name: Update README
+        run: |
+          # Create readme_updated.md as a copy of the original
+          cp README.md readme_updated.md
+          
+          # Check if we have the screenshots section already
+          if grep -q "## Screenshots" readme_updated.md; then
+            # Replace the existing screenshots section
+            sed -i '/## Screenshots/,/## Development Setup/c\## Screenshots\n\n<div align="center">\n  <img src="assets/screenshots/main_screen_default_latest.png" width="280" />\n  <img src="assets/screenshots/main_screen_timer_running_latest.png" width="280" />\n  <img src="assets/screenshots/main_screen_20min_latest.png" width="280" />\n</div>\n\n## App Demo\n\n<div align="center">\n  <img src="assets/videos/app_demo.gif" width="280" />\n</div>\n\n## Development Setup' readme_updated.md
+          else
+            # Add the screenshots section before "Development Setup"
+            sed -i '/## Development Setup/i ## Screenshots\n\n<div align="center">\n  <img src="assets/screenshots/main_screen_default_latest.png" width="280" />\n  <img src="assets/screenshots/main_screen_timer_running_latest.png" width="280" />\n  <img src="assets/screenshots/main_screen_20min_latest.png" width="280" />\n</div>\n\n## App Demo\n\n<div align="center">\n  <img src="assets/videos/app_demo.gif" width="280" />\n</div>\n' readme_updated.md
+          fi
+          
+          # Replace the original README
+          mv readme_updated.md README.md
+      
+      # Rename the screenshots to "latest" versions for consistent links
+      - name: Create latest asset versions
+        run: |
+          # For each screenshot type, copy the most recent one to a "latest" filename
+          for TYPE in main_screen_default main_screen_timer_running main_screen_20min; do
+            LATEST=$(find ./assets/screenshots -name "${TYPE}_*.png" | sort -r | head -n 1)
+            if [ -n "$LATEST" ]; then
+              cp "$LATEST" "./assets/screenshots/${TYPE}_latest.png"
+            fi
+          done
+      
+      # Create a branch and PR with the updated assets
+      - name: Create PR with updated assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Set Git user
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          
+          # Get current date for branch name
+          DATE=$(date +'%Y%m%d')
+          BRANCH_NAME="update-readme-assets-${DATE}"
+          
+          # Create a new branch
+          git checkout -b $BRANCH_NAME
+          
+          # Add and commit changes
+          git add assets/ README.md
+          git commit -m "Update README screenshots and demo video [skip ci]"
+          
+          # Push the branch
+          git push -u origin $BRANCH_NAME
+          
+          # Create a PR
+          gh pr create --title "Update README screenshots and demo video" \
+            --body "## Auto-generated README Assets Update
+            
+            This PR updates the screenshots and demo video in the README to reflect the current state of the app.
+            
+            ### Changes:
+            - Updated app screenshots
+            - Updated app demo video/GIF
+            - Updated README references
+            
+            This PR was automatically generated by the update-readme-assets workflow.
+            " \
+            --base main \
+            --head $BRANCH_NAME

--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@ An ultra simple, free meditation app for Android.
 - Keeps screen active during meditation with wake lock
 - Minimal permissions required (only vibration)
 
+## Screenshots
+
+<div align="center">
+  <!-- Screenshots will be automatically updated by CI workflow -->
+  <p>Screenshots will appear here after the first workflow run</p>
+</div>
+
+## App Demo
+
+<div align="center">
+  <!-- Demo video will be automatically updated by CI workflow -->
+  <p>App demo will appear here after the first workflow run</p>
+</div>
+
 ## Download
 
 You can download the latest APK directly from the [GitHub Releases](https://github.com/patflynn/vibe/releases) page.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,9 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
+        
+        // Add additional runner for screenshot tests
+        testInstrumentationRunnerForScreenshots "dev.broken.app.vibe.screenshots.ScreenshotTestRunner"
     }
     
     // Define signing configuration only for release builds
@@ -109,6 +112,10 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.6.1'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.6.1'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'
+    
+    // Screenshot testing
+    androidTestImplementation 'androidx.test:runner:1.6.2'
+    androidTestImplementation 'tools.fastlane:screengrab:2.1.1'
     
     // Test orchestrator
     androidTestUtil 'androidx.test:orchestrator:1.5.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
         
-        // Add additional runner for screenshot tests
-        testInstrumentationRunnerForScreenshots "dev.broken.app.vibe.screenshots.ScreenshotTestRunner"
+        // Add parameters for screenshot tests
+        testInstrumentationRunnerArguments captureScreenshots: 'true'
     }
     
     // Define signing configuration only for release builds

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    
+    <!-- Permissions needed for screenshots and screen recording -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    
+    <!-- Test-only permissions -->
+    <uses-permission android:name="android.permission.DISABLE_KEYGUARD" tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    
+</manifest>

--- a/app/src/androidTest/java/dev/broken/app/vibe/screenshots/AppDemoRecordingTest.kt
+++ b/app/src/androidTest/java/dev/broken/app/vibe/screenshots/AppDemoRecordingTest.kt
@@ -1,0 +1,86 @@
+package dev.broken.app.vibe.screenshots
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.swipeRight
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.broken.app.vibe.MainActivity
+import dev.broken.app.vibe.R
+import dev.broken.app.vibe.TestHelpers
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Test class that records a demonstration video of the app in use.
+ * This will be used for the project README and documentation.
+ */
+@RunWith(AndroidJUnit4::class)
+class AppDemoRecordingTest {
+
+    private lateinit var activityScenario: ActivityScenario<MainActivity>
+    private val screenRecorder = ScreenRecordingHelper()
+
+    @Before
+    fun setup() {
+        // Configure test environment for demo recording
+        TestHelpers.configureForTesting()
+        
+        // Launch the main activity
+        activityScenario = ActivityScenario.launch(MainActivity::class.java)
+    }
+    
+    @After
+    fun tearDown() {
+        // Reset test configuration
+        TestHelpers.resetTestConfiguration()
+        
+        // Close the activity
+        activityScenario.close()
+    }
+    
+    @Test
+    fun recordAppDemonstration() {
+        // Start screen recording
+        screenRecorder.startRecording(
+            filename = "vibe_app_demo",
+            timeLimit = 20 // 20 seconds max for the demo
+        )
+        
+        try {
+            // Wait for UI to stabilize at the beginning
+            TestHelpers.waitFor(2000)
+            
+            // Adjust slider to show different time values
+            onView(withId(R.id.durationSlider)).perform(swipeRight())
+            TestHelpers.waitFor(1500)
+            
+            // Start the timer
+            onView(withId(R.id.startButton)).perform(click())
+            TestHelpers.waitFor(3000)
+            
+            // Pause the timer
+            onView(withId(R.id.startButton)).perform(click())
+            TestHelpers.waitFor(1500)
+            
+            // Adjust slider again
+            onView(withId(R.id.durationSlider)).perform(swipeRight())
+            TestHelpers.waitFor(1500)
+            
+            // Start timer again
+            onView(withId(R.id.startButton)).perform(click())
+            TestHelpers.waitFor(3000)
+            
+            // Pause again
+            onView(withId(R.id.startButton)).perform(click())
+            TestHelpers.waitFor(2000)
+            
+        } finally {
+            // Stop recording regardless of any test failures
+            screenRecorder.stopRecording()
+        }
+    }
+}

--- a/app/src/androidTest/java/dev/broken/app/vibe/screenshots/AppDemoRecordingTest.kt
+++ b/app/src/androidTest/java/dev/broken/app/vibe/screenshots/AppDemoRecordingTest.kt
@@ -29,6 +29,9 @@ class AppDemoRecordingTest {
         // Configure test environment for demo recording
         TestHelpers.configureForTesting()
         
+        // Initialize screenshot helper
+        ScreenshotHelper.initialize()
+        
         // Launch the main activity
         activityScenario = ActivityScenario.launch(MainActivity::class.java)
     }

--- a/app/src/androidTest/java/dev/broken/app/vibe/screenshots/ScreenRecordingHelper.kt
+++ b/app/src/androidTest/java/dev/broken/app/vibe/screenshots/ScreenRecordingHelper.kt
@@ -1,0 +1,110 @@
+package dev.broken.app.vibe.screenshots
+
+import android.os.Environment
+import android.os.ParcelFileDescriptor
+import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import java.io.File
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Helper class for screen recording during tests
+ */
+class ScreenRecordingHelper {
+    private var recordingProcess: Process? = null
+    private var outputFile: File? = null
+    private var pfd: ParcelFileDescriptor? = null
+    private val TAG = "ScreenRecordingHelper"
+    
+    /**
+     * Start screen recording
+     * @param filename Base filename for the recording (without extension)
+     * @param width Width of the video (default 720)
+     * @param height Height of the video (default 1280)
+     * @param timeLimit Time limit in seconds (default 30)
+     * @param bitRate Bit rate in Mbps (default 4)
+     * @return True if recording started successfully
+     */
+    fun startRecording(
+        filename: String,
+        width: Int = 720,
+        height: Int = 1280,
+        timeLimit: Int = 30,
+        bitRate: Int = 4
+    ): Boolean {
+        try {
+            // Create output file
+            outputFile = createOutputFile(filename)
+            
+            // Get UI device instance
+            val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            
+            // Build the command for screen recording
+            val command = "screenrecord --size ${width}x${height} " +
+                          "--time-limit $timeLimit " +
+                          "--bit-rate ${bitRate}000000 " +
+                          "${outputFile?.absolutePath}"
+            
+            // Start the recording process
+            recordingProcess = Runtime.getRuntime().exec(command)
+            
+            Log.d(TAG, "Screen recording started: ${outputFile?.absolutePath}")
+            return true
+        } catch (e: IOException) {
+            Log.e(TAG, "Failed to start screen recording: ${e.message}")
+            return false
+        }
+    }
+    
+    /**
+     * Stop the current screen recording
+     * @return Path to the recorded file or null if recording failed
+     */
+    fun stopRecording(): String? {
+        try {
+            // Send SIGINT to the process to stop recording gracefully
+            recordingProcess?.let {
+                if (it.isAlive) {
+                    it.destroy()
+                    it.waitFor()
+                }
+            }
+            
+            // Close file descriptor if open
+            pfd?.close()
+            
+            Log.d(TAG, "Screen recording stopped: ${outputFile?.absolutePath}")
+            return outputFile?.absolutePath
+        } catch (e: Exception) {
+            Log.e(TAG, "Error stopping screen recording: ${e.message}")
+            return null
+        } finally {
+            recordingProcess = null
+            pfd = null
+        }
+    }
+    
+    /**
+     * Create output file for the recording
+     */
+    private fun createOutputFile(filename: String): File {
+        // Get the external storage directory for movies
+        val storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES)
+        val screenRecordingDir = File(storageDir, "screenshots")
+        
+        // Ensure the directory exists
+        if (!screenRecordingDir.exists()) {
+            screenRecordingDir.mkdirs()
+        }
+        
+        // Create a timestamp for unique filenames
+        val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
+        
+        // Create the file
+        return File(screenRecordingDir, "${filename}_${timeStamp}.mp4")
+    }
+}

--- a/app/src/androidTest/java/dev/broken/app/vibe/screenshots/ScreenshotCaptureTest.kt
+++ b/app/src/androidTest/java/dev/broken/app/vibe/screenshots/ScreenshotCaptureTest.kt
@@ -43,6 +43,9 @@ class ScreenshotCaptureTest {
         // Configure test environment for predictable screenshots
         TestHelpers.configureForTesting()
         
+        // Initialize screenshot helper
+        ScreenshotHelper.initialize()
+        
         // Create screenshot directory if it doesn't exist
         createScreenshotDirectory()
         

--- a/app/src/androidTest/java/dev/broken/app/vibe/screenshots/ScreenshotCaptureTest.kt
+++ b/app/src/androidTest/java/dev/broken/app/vibe/screenshots/ScreenshotCaptureTest.kt
@@ -1,0 +1,176 @@
+package dev.broken.app.vibe.screenshots
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.os.Environment
+import android.util.Log
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.swipeRight
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.screenshot.Screenshot
+import dev.broken.app.vibe.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.*
+
+/**
+ * Test class responsible for generating screenshots and demo assets for the README.
+ * These tests don't validate functionality but rather capture visual assets of the app.
+ */
+@RunWith(AndroidJUnit4::class)
+class ScreenshotCaptureTest {
+
+    private lateinit var activityScenario: ActivityScenario<MainActivity>
+    private lateinit var context: Context
+    private val screenshotDir = "screenshots"
+    private val TAG = "ScreenshotTest"
+
+    @Before
+    fun setup() {
+        // Get the context
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+        
+        // Configure test environment for predictable screenshots
+        TestHelpers.configureForTesting()
+        
+        // Create screenshot directory if it doesn't exist
+        createScreenshotDirectory()
+        
+        // Launch the main activity
+        activityScenario = ActivityScenario.launch(MainActivity::class.java)
+    }
+    
+    @After
+    fun tearDown() {
+        // Reset test configuration
+        TestHelpers.resetTestConfiguration()
+        
+        // Close the activity
+        activityScenario.close()
+    }
+    
+    @Test
+    fun captureMainScreenDefault() {
+        // Wait for the UI to stabilize
+        TestHelpers.waitFor(1000)
+        
+        // Take screenshot of the default timer screen
+        takeScreenshot("main_screen_default")
+    }
+    
+    @Test
+    fun captureMainScreenTimerRunning() {
+        // Wait for the UI to stabilize
+        TestHelpers.waitFor(1000)
+        
+        // Start the timer
+        onView(withId(R.id.startButton)).perform(click())
+        
+        // Wait for the UI to update
+        TestHelpers.waitFor(500)
+        
+        // Take screenshot with timer running
+        takeScreenshot("main_screen_timer_running")
+    }
+    
+    @Test
+    fun captureDifferentTimerDurations() {
+        // Wait for the UI to stabilize
+        TestHelpers.waitFor(1000)
+        
+        // Adjust timer to 20 minutes by swiping right on the slider
+        onView(withId(R.id.durationSlider)).perform(swipeRight())
+        
+        // Wait for the UI to update
+        TestHelpers.waitFor(500)
+        
+        // Take screenshot with different timer duration
+        takeScreenshot("main_screen_20min")
+    }
+    
+    /**
+     * Create a directory for storing screenshots if it doesn't exist
+     */
+    private fun createScreenshotDirectory() {
+        try {
+            // Get the external storage directory for pictures
+            val storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+            val screenshotDirectory = File(storageDir, screenshotDir)
+            
+            if (!screenshotDirectory.exists()) {
+                val success = screenshotDirectory.mkdirs()
+                if (success) {
+                    Log.d(TAG, "Screenshot directory created successfully")
+                } else {
+                    Log.e(TAG, "Failed to create screenshot directory")
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error creating screenshot directory: ${e.message}")
+        }
+    }
+    
+    /**
+     * Take a screenshot and save it with the given filename
+     */
+    private fun takeScreenshot(filename: String) {
+        try {
+            // Capture the screenshot
+            val screenshot = Screenshot.capture()
+            val bitmap = screenshot.bitmap
+            
+            // Get the file to save to
+            val screenshotFile = getScreenshotFile(filename)
+            
+            // Save the bitmap to the file
+            saveBitmap(bitmap, screenshotFile)
+            
+            Log.d(TAG, "Screenshot saved to $screenshotFile")
+        } catch (e: Exception) {
+            Log.e(TAG, "Error taking screenshot: ${e.message}")
+        }
+    }
+    
+    /**
+     * Get a file reference for saving the screenshot
+     */
+    private fun getScreenshotFile(filename: String): File {
+        // Get the external storage directory for pictures
+        val storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+        val screenshotDirectory = File(storageDir, screenshotDir)
+        
+        // Ensure the directory exists
+        if (!screenshotDirectory.exists()) {
+            screenshotDirectory.mkdirs()
+        }
+        
+        // Create a timestamp for unique filenames
+        val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
+        
+        // Return the file reference
+        return File(screenshotDirectory, "${filename}_${timeStamp}.png")
+    }
+    
+    /**
+     * Save a bitmap to a file
+     */
+    private fun saveBitmap(bitmap: Bitmap, file: File) {
+        try {
+            FileOutputStream(file).use { out ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+            }
+        } catch (e: IOException) {
+            Log.e(TAG, "Error saving bitmap: ${e.message}")
+        }
+    }
+}

--- a/app/src/androidTest/java/dev/broken/app/vibe/screenshots/ScreenshotHelper.kt
+++ b/app/src/androidTest/java/dev/broken/app/vibe/screenshots/ScreenshotHelper.kt
@@ -10,45 +10,40 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 /**
- * Custom test runner for capturing screenshots and recordings
- * Used to generate assets for the README and documentation
+ * This class is an extension of the test runner for the screenshot tests
+ * but we're not actually using it as the main runner to avoid CI issues.
+ * It serves as a helper class for screenshot organization.
  */
-class ScreenshotTestRunner : AndroidJUnitRunner() {
+class ScreenshotHelper {
 
     companion object {
-        private const val TAG = "ScreenshotTestRunner"
+        private const val TAG = "ScreenshotHelper"
         private const val SCREENSHOTS_ARG = "captureScreenshots"
-    }
-
-    override fun onCreate(arguments: Bundle) {
-        val newArgs = Bundle(arguments)
-        val captureScreenshots = arguments.getString(SCREENSHOTS_ARG, "true")
-
-        // Set test-specific flags if needed
-        Log.d(TAG, "Creating ScreenshotTestRunner with captureScreenshots=$captureScreenshots")
-
-        // Make test output more organized by using a timestamp for this test run
-        val timestamp = getTimestampString()
-        newArgs.putString("timestamp", timestamp)
         
-        // Create directories for screenshots/recordings if they don't exist
-        createOutputDirectories()
-        
-        super.onCreate(newArgs)
-    }
-
-    override fun finish(resultCode: Int, results: Bundle) {
-        Log.i(TAG, "ScreenshotTestRunner finished with resultCode=$resultCode")
-        
-        // Process and move files to the correct location if needed
-        try {
-            collectScreenshotAssets()
-        } catch (e: Exception) {
-            Log.e(TAG, "Error collecting screenshot assets: ${e.message}")
+        /**
+         * Initialize screenshot directories and settings
+         */
+        fun initialize() {
+            // Get timestamp for organizing output
+            val timestamp = getTimestampString()
+            Log.d(TAG, "Initializing ScreenshotHelper with timestamp=$timestamp")
+            
+            // Create output directories
+            createOutputDirectories()
         }
         
-        super.finish(resultCode, results)
-    }
+        /**
+         * Collect and process screenshot assets after tests
+         */
+        fun collectAssets() {
+            Log.i(TAG, "Collecting screenshot assets")
+            
+            try {
+                processScreenshotAssets()
+            } catch (e: Exception) {
+                Log.e(TAG, "Error collecting screenshot assets: ${e.message}")
+            }
+        }
 
     /**
      * Create output directories for screenshots and recordings
@@ -74,10 +69,10 @@ class ScreenshotTestRunner : AndroidJUnitRunner() {
     }
 
     /**
-     * Collect and organize all screenshot assets after tests complete
+     * Process all screenshot assets after tests complete
      */
-    private fun collectScreenshotAssets() {
-        Log.d(TAG, "Collecting screenshot assets")
+    private fun processScreenshotAssets() {
+        Log.d(TAG, "Processing screenshot assets")
         
         // Assets will be collected automatically by the CI process from their
         // output locations, so this is just a placeholder for any additional

--- a/app/src/androidTest/java/dev/broken/app/vibe/screenshots/ScreenshotTestRunner.kt
+++ b/app/src/androidTest/java/dev/broken/app/vibe/screenshots/ScreenshotTestRunner.kt
@@ -1,0 +1,95 @@
+package dev.broken.app.vibe.screenshots
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnitRunner
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.*
+
+/**
+ * Custom test runner for capturing screenshots and recordings
+ * Used to generate assets for the README and documentation
+ */
+class ScreenshotTestRunner : AndroidJUnitRunner() {
+
+    companion object {
+        private const val TAG = "ScreenshotTestRunner"
+        private const val SCREENSHOTS_ARG = "captureScreenshots"
+    }
+
+    override fun onCreate(arguments: Bundle) {
+        val newArgs = Bundle(arguments)
+        val captureScreenshots = arguments.getString(SCREENSHOTS_ARG, "true")
+
+        // Set test-specific flags if needed
+        Log.d(TAG, "Creating ScreenshotTestRunner with captureScreenshots=$captureScreenshots")
+
+        // Make test output more organized by using a timestamp for this test run
+        val timestamp = getTimestampString()
+        newArgs.putString("timestamp", timestamp)
+        
+        // Create directories for screenshots/recordings if they don't exist
+        createOutputDirectories()
+        
+        super.onCreate(newArgs)
+    }
+
+    override fun finish(resultCode: Int, results: Bundle) {
+        Log.i(TAG, "ScreenshotTestRunner finished with resultCode=$resultCode")
+        
+        // Process and move files to the correct location if needed
+        try {
+            collectScreenshotAssets()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error collecting screenshot assets: ${e.message}")
+        }
+        
+        super.finish(resultCode, results)
+    }
+
+    /**
+     * Create output directories for screenshots and recordings
+     */
+    private fun createOutputDirectories() {
+        try {
+            val context = InstrumentationRegistry.getInstrumentation().context
+            val screenshotDir = File(context.getExternalFilesDir(null), "screenshots")
+            val recordingsDir = File(context.getExternalFilesDir(null), "recordings")
+            
+            if (!screenshotDir.exists()) {
+                screenshotDir.mkdirs()
+            }
+            
+            if (!recordingsDir.exists()) {
+                recordingsDir.mkdirs()
+            }
+            
+            Log.d(TAG, "Created output directories: screenshots=${screenshotDir.absolutePath}, recordings=${recordingsDir.absolutePath}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Error creating output directories: ${e.message}")
+        }
+    }
+
+    /**
+     * Collect and organize all screenshot assets after tests complete
+     */
+    private fun collectScreenshotAssets() {
+        Log.d(TAG, "Collecting screenshot assets")
+        
+        // Assets will be collected automatically by the CI process from their
+        // output locations, so this is just a placeholder for any additional
+        // processing that might be needed
+    }
+
+    /**
+     * Generate a timestamp string for the current test run
+     */
+    @SuppressLint("SimpleDateFormat")
+    private fun getTimestampString(): String {
+        val dateFormat = SimpleDateFormat("yyyyMMdd_HHmmss")
+        return dateFormat.format(Date())
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements automated screenshot and video generation for the README as requested in issue #46, with a clean implementation that doesn't touch the Play Store publishing workflows.

## Implementation
- Added UI tests that capture screenshots of the app in different states
- Created screen recording functionality to generate app demo videos
- Set up asset directories for organizing visual media
- Added GitHub workflow to automatically update screenshots and videos weekly
- Updated README with sections for screenshots and demo video

## Key Features
- **Self-maintaining**: Assets update automatically as the app evolves
- **Scheduled updates**: Weekly runs ensure assets stay current
- **PR-triggered**: Updates when code changes are merged
- **Consistent links**: Uses "latest" versions for stable README references
- **Creates PRs**: Workflow creates PRs with updates rather than direct commits

## Test Plan
- The workflow will run automatically after merging
- Screenshots and video will be generated and added to the README
- Subsequent app changes will trigger updates to the visual assets

Closes #46

🤖 Generated with [Claude Code](https://claude.ai/code)