### PR TITLE
Fix update-readme-assets workflow to use correct Google Services credentials

### DIFF
--- a/.github/workflows/update-readme-assets.yml
+++ b/.github/workflows/update-readme-assets.yml
@@ -47,6 +47,14 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       
+      # Decode Google Services config
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: |
+          echo $GOOGLE_SERVICES_JSON_B64 | base64 --decode > app/google-services.json
+          echo "google-services.json created successfully."
+      
       # Build debug APK
       - name: Build debug APK
         run: ./gradlew assembleDebug
@@ -55,51 +63,71 @@ jobs:
       - name: Build test APK
         run: ./gradlew assembleDebugAndroidTest
       
+      # Authentication with Google Cloud
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
+          project_id: '${{ secrets.FIREBASE_PROJECT_ID }}'
+      
+      # Setup Google Cloud SDK
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.FIREBASE_PROJECT_ID }}
+      
       # Run tests using Firebase Test Lab
       - name: Run tests on Firebase Test Lab
-        env:
-          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
         run: |
-          # Set up gcloud auth
-          echo $GCLOUD_SERVICE_KEY | base64 --decode > ${HOME}/gcloud-service-key.json
-          gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
-          gcloud --quiet config set project broken-vibe
+          
+          # List available device models first for debugging
+          echo "Available device models:"
+          gcloud firebase test android models list --format="value(MODEL_ID)" | grep -i pixel
+          
+          # Run tests with newer devices
+          RESULTS_DIR="github-readme-assets-${GITHUB_REF_NAME}_${GITHUB_RUN_NUMBER}"
+          echo "Using results directory: $RESULTS_DIR"
           
           # Run the tests on Firebase Test Lab with specific test class
           gcloud firebase test android run \
             --type instrumentation \
             --app app/build/outputs/apk/debug/app-debug.apk \
             --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
-            --device model=Pixel2,version=30,locale=en,orientation=portrait \
+            --device model=redfin,version=30,locale=en,orientation=portrait \
             --timeout 5m \
-            --results-bucket cloud-test-${GITHUB_REPOSITORY_OWNER}-${GITHUB_REPOSITORY#*/} \
-            --results-dir=${GITHUB_REF_NAME}_${GITHUB_RUN_NUMBER} \
+            --results-bucket gs://${{ secrets.FIREBASE_TEST_BUCKET }} \
+            --results-dir=$RESULTS_DIR \
             --environment-variables clearPackageData=true \
             --test-targets "class dev.broken.app.vibe.EspressoScreenshotTest"
+            
+          # Save the results dir for the next step
+          echo "RESULTS_DIR=$RESULTS_DIR" >> $GITHUB_ENV
           
           # Create directories for artifacts
           mkdir -p screenshots
           mkdir -p recordings
           
-          # Download artifacts from Google Cloud Storage
-          TEST_DIR=${GITHUB_REF_NAME}_${GITHUB_RUN_NUMBER}
-          BUCKET_PATH="gs://cloud-test-${GITHUB_REPOSITORY_OWNER}-${GITHUB_REPOSITORY#*/}/${TEST_DIR}"
+          # Download test results
+          # Wait a moment for test results to be available
+          sleep 10
+          
+          # Set bucket path
+          BUCKET_PATH="gs://${{ secrets.FIREBASE_TEST_BUCKET }}/$RESULTS_DIR"
           
           # List artifacts to understand the structure
           echo "Listing Firebase Test Lab artifacts..."
-          gsutil ls -la ${BUCKET_PATH}
+          gsutil ls -la $BUCKET_PATH || echo "Could not list bucket contents yet"
           
           # Copy screenshots - they come from Espresso tests
           echo "Downloading screenshots..."
-          gsutil -m cp -r ${BUCKET_PATH}/*/artifacts/screenshots ./screenshots || true
-          # As a fallback, try to copy all PNG files
-          gsutil -m cp -r "${BUCKET_PATH}/**/*.png" ./screenshots/ || true
+          gsutil -m cp -r "$BUCKET_PATH/*/artifacts/screenshots" ./screenshots/ || echo "No screenshots found in artifacts/screenshots"
+          gsutil -m cp -r "$BUCKET_PATH/*/*.png" ./screenshots/ || echo "No PNG files found directly in results"
           
           # Copy video recording
           echo "Downloading video recording..."
-          gsutil -m cp -r ${BUCKET_PATH}/*/artifacts/video.mp4 ./recordings/ || true
-          # As a fallback, try to look for all MP4 files
-          gsutil -m cp -r "${BUCKET_PATH}/**/*.mp4" ./recordings/ || true
+          gsutil -m cp -r "$BUCKET_PATH/*/artifacts/video.mp4" ./recordings/ || echo "No video found in artifacts/video.mp4"
+          gsutil -m cp -r "$BUCKET_PATH/*/*.mp4" ./recordings/ || echo "No MP4 files found directly in results"
           
           # Show what we've downloaded
           echo "Downloaded artifacts:"


### PR DESCRIPTION
## Summary
This PR fixes the failing update-readme-assets workflow by updating the authentication method to match other Firebase workflows:

- Added google-services.json decoding step
- Updated Google Cloud authentication to use actions/auth instead of manual method
- Updated bucket configuration to use the correct secrets
- Improved handling of results directory with better error handling

## Test plan
The fixes are based on the working firebase-test-lab.yml workflow and should resolve the current build errors.

🤖 Generated with [Claude Code](https://claude.ai/code)