### PR TITLE
Fix screenshot tests compilation errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,7 +109,6 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.6.2'
     androidTestImplementation 'androidx.test:rules:1.6.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1:screencapture'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.6.1'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.6.1'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.6.2'
     androidTestImplementation 'androidx.test:rules:1.6.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1:screencapture'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.6.1'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.6.1'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'

--- a/app/src/androidTest/java/dev/broken/app/vibe/EspressoScreenshotTest.kt
+++ b/app/src/androidTest/java/dev/broken/app/vibe/EspressoScreenshotTest.kt
@@ -3,35 +3,18 @@ package dev.broken.app.vibe
 import android.graphics.Bitmap
 import android.os.Environment
 import android.util.Log
+import android.view.View
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.swipeRight
-import androidx.test.espresso.matcher.ViewMatchers.withId
-// Espresso screenshot extension functions
-import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.matcher.ViewMatchers
-import android.graphics.Bitmap
-import androidx.test.platform.app.InstrumentationRegistry
-import java.io.File
-import java.io.FileOutputStream
-
-// Extension function for capturing screenshots
-fun ViewInteraction.captureToBitmap(): Bitmap {
-    var bitmap: Bitmap? = null
-    perform(object : androidx.test.espresso.ViewAction {
-        override fun getConstraints() = ViewMatchers.isAssignableTo(android.view.View::class.java)
-        override fun getDescription() = "Capture view to bitmap"
-        override fun perform(uiController: androidx.test.espresso.UiController, view: android.view.View) {
-            view.isDrawingCacheEnabled = true
-            view.buildDrawingCache()
-            bitmap = view.drawingCache
-            uiController.loopMainThreadUntilIdle()
-        }
-    })
-    return bitmap ?: throw IllegalStateException("Failed to capture bitmap from view")
-}
-
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers.any
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.After
@@ -40,6 +23,25 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
 import java.io.FileOutputStream
+
+/**
+ * Extension function for capturing screenshots since Espresso's built-in 
+ * screenshot API is not available in the current configuration
+ */
+fun ViewInteraction.captureToBitmap(): Bitmap {
+    var bitmap: Bitmap? = null
+    perform(object : ViewAction {
+        override fun getConstraints(): Matcher<View> = any(View::class.java)
+        override fun getDescription() = "Capture view to bitmap"
+        override fun perform(uiController: UiController, view: View) {
+            view.isDrawingCacheEnabled = true
+            view.buildDrawingCache()
+            bitmap = view.drawingCache
+            uiController.loopMainThreadUntilIdle()
+        }
+    })
+    return bitmap ?: throw IllegalStateException("Failed to capture bitmap from view")
+}
 
 /**
  * Test for capturing screenshots using Espresso's native screenshot API.

--- a/app/src/androidTest/java/dev/broken/app/vibe/EspressoScreenshotTest.kt
+++ b/app/src/androidTest/java/dev/broken/app/vibe/EspressoScreenshotTest.kt
@@ -25,8 +25,7 @@ import java.io.File
 import java.io.FileOutputStream
 
 /**
- * Extension function for capturing screenshots since Espresso's built-in 
- * screenshot API is not available in the current configuration
+ * Extension function for capturing screenshots as a fallback for Espresso's screenshot API
  */
 fun ViewInteraction.captureToBitmap(): Bitmap {
     var bitmap: Bitmap? = null

--- a/app/src/androidTest/java/dev/broken/app/vibe/EspressoScreenshotTest.kt
+++ b/app/src/androidTest/java/dev/broken/app/vibe/EspressoScreenshotTest.kt
@@ -8,7 +8,30 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.swipeRight
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.screenshot.captureToBitmap
+// Espresso screenshot extension functions
+import androidx.test.espresso.ViewInteraction
+import androidx.test.espresso.matcher.ViewMatchers
+import android.graphics.Bitmap
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+import java.io.FileOutputStream
+
+// Extension function for capturing screenshots
+fun ViewInteraction.captureToBitmap(): Bitmap {
+    var bitmap: Bitmap? = null
+    perform(object : androidx.test.espresso.ViewAction {
+        override fun getConstraints() = ViewMatchers.isAssignableTo(android.view.View::class.java)
+        override fun getDescription() = "Capture view to bitmap"
+        override fun perform(uiController: androidx.test.espresso.UiController, view: android.view.View) {
+            view.isDrawingCacheEnabled = true
+            view.buildDrawingCache()
+            bitmap = view.drawingCache
+            uiController.loopMainThreadUntilIdle()
+        }
+    })
+    return bitmap ?: throw IllegalStateException("Failed to capture bitmap from view")
+}
+
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.After

--- a/app/src/androidTest/java/dev/broken/app/vibe/screenshots/ScreenshotHelper.kt
+++ b/app/src/androidTest/java/dev/broken/app/vibe/screenshots/ScreenshotHelper.kt
@@ -87,4 +87,5 @@ class ScreenshotHelper {
         val dateFormat = SimpleDateFormat("yyyyMMdd_HHmmss")
         return dateFormat.format(Date())
     }
+  }
 }


### PR DESCRIPTION
## Summary
This PR fixes the compilation errors in the screenshot tests:

- Fix missing closing bracket in ScreenshotHelper.kt
- Add Espresso screenshot dependency to build.gradle
- Add custom captureToBitmap implementation in EspressoScreenshotTest

These changes properly fix the source code instead of trying to patch it during the build process.

## Test plan
The fixes should allow the screenshot tests to compile and run successfully in the CI workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)