### PR TITLE
Fix branch naming in README assets workflow

### DIFF
--- a/.github/workflows/update-readme-assets.yml
+++ b/.github/workflows/update-readme-assets.yml
@@ -285,9 +285,9 @@ jobs:
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
           
-          # Get current date for branch name
-          DATE=$(date +'%Y%m%d')
-          BRANCH_NAME="update-readme-assets-${DATE}"
+          # Get current date and time for branch name to ensure uniqueness
+          DATETIME=$(date +'%Y%m%d-%H%M%S')
+          BRANCH_NAME="update-readme-assets-${DATETIME}"
           
           # Check if we have changes to commit
           if [[ -z "$(git status --porcelain assets/ README.md)" ]]; then


### PR DESCRIPTION
## Summary
This PR fixes an issue in the README assets workflow where branch name collisions can occur if multiple workflow runs happen on the same day.

### Changes:
- Add timestamp (hours, minutes, seconds) to branch name for uniqueness
- Prevents push rejections when multiple workflow runs happen on the same day

### Problem Fixed
The previous implementation only used the date (YYYYMMDD) in the branch name, which caused collisions if multiple runs happened on the same day. This resulted in errors like:

```
To https://github.com/patflynn/vibe
 \! [rejected]        update-readme-assets-20250406 -> update-readme-assets-20250406 (fetch first)
error: failed to push some refs to 'https://github.com/patflynn/vibe'
```

The fix adds hours, minutes, and seconds to ensure each branch name is unique.

🤖 Generated with [Claude Code](https://claude.ai/code)