### PR TITLE
Fix screenshot downloading in README assets workflow

### DIFF
--- a/.github/workflows/update-readme-assets.yml
+++ b/.github/workflows/update-readme-assets.yml
@@ -121,8 +121,18 @@ jobs:
           
           # Copy screenshots - they come from Espresso tests
           echo "Downloading screenshots..."
+          # First, list all files in the bucket to understand the structure
+          echo "Listing all files in the bucket for debugging:"
+          gsutil ls -r "$BUCKET_PATH" || echo "Could not list complete bucket contents"
+          
+          # Try to find and copy screenshots from multiple possible locations
           gsutil -m cp -r "$BUCKET_PATH/*/artifacts/screenshots" ./screenshots/ || echo "No screenshots found in artifacts/screenshots"
           gsutil -m cp -r "$BUCKET_PATH/*/*.png" ./screenshots/ || echo "No PNG files found directly in results"
+          gsutil -m cp -r "$BUCKET_PATH/*/*/*.png" ./screenshots/ || echo "No PNG files found in subdirectories"
+          gsutil -m cp -r "$BUCKET_PATH/*/test_data/*.png" ./screenshots/ || echo "No PNG files found in test_data"
+          
+          # Check for external storage directory where our tests save files
+          gsutil -m cp -r "$BUCKET_PATH/*/sdcard/Android/data/dev.broken.app.vibe/files/Pictures/screenshots/*.png" ./screenshots/ || echo "No screenshots found in app external storage"
           
           # Copy video recording
           echo "Downloading video recording..."


### PR DESCRIPTION
## Summary
This PR fixes the issue where screenshots are not being found and downloaded from Firebase Test Lab, causing placeholder text to be used instead of actual screenshots.

### The Issue
In the current workflow, the screenshots taken by the tests are being saved to the device's external storage, but the workflow is looking for them in different locations.

### The Fix
- Add more comprehensive search paths for finding screenshots in Firebase Test Lab results
- List all files in the bucket for debugging purposes
- Check for screenshots in various possible locations including the app's external storage
- Keep the existing paths as fallbacks for backward compatibility

### Current Behavior
The workflow is currently downloading the video successfully but using placeholder text for screenshots:
```
Missing default screen screenshot - creating placeholder
echo "Default Screen Placeholder" > "./assets/screenshots/main_screen_default_${TIMESTAMP}.png"
```

### Expected Behavior After Fix
The workflow should now be able to find and download the actual screenshots taken during the tests, providing real images instead of placeholders in the README.

🤖 Generated with [Claude Code](https://claude.ai/code)