### PR TITLE
Fix Play Store testing workflow status

### DIFF
--- a/.github/workflows/play-store-publish-testing.yml
+++ b/.github/workflows/play-store-publish-testing.yml
@@ -161,7 +161,7 @@ jobs:
           packageName: dev.broken.app.vibe
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
           track: ${{ env.TRACK }}
-          status: completed
+          status: draft
           releaseName: ${{ env.VERSION_NAME }}
           mappingFile: app/build/outputs/mapping/release/mapping.txt
           whatsNewDirectory: app/src/main/play/release-notes


### PR DESCRIPTION
## Summary
- Changes the status from 'completed' to 'draft' in the testing track workflow
- Fixes the "Only releases with status draft may be created on draft app" error
- Only affects internal/alpha/beta testing tracks, not production releases

## Test plan
- When the workflow runs, releases will be created as drafts in the Play Console
- Releases can then be manually reviewed before publishing to testers

🤖 Generated with [Claude Code](https://claude.ai/code)