### PR TITLE
Fix settings gear positioning - replace complex inset handling with fitsSystemWindows

### DIFF
--- a/app/src/main/java/dev/broken/app/vibe/MainActivity.kt
+++ b/app/src/main/java/dev/broken/app/vibe/MainActivity.kt
@@ -13,9 +13,6 @@ import android.os.VibratorManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.WindowManager
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowCompat
 import android.widget.TextView
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
@@ -53,10 +50,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        
-        // Enable edge-to-edge display for proper system bar handling
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-        
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         
@@ -75,7 +68,6 @@ class MainActivity : AppCompatActivity() {
         setupTouchListener()
         setupSettingsButton()
         setupTimerLongPress()
-        setupSystemWindowInsets()
         
         // Show controls briefly at startup, then hide them
         showControlsTemporarily()
@@ -278,24 +270,6 @@ class MainActivity : AppCompatActivity() {
         }
     }
     
-    private fun setupSystemWindowInsets() {
-        // Handle system window insets to prevent overlap with status bar
-        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, windowInsets ->
-            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-            
-            // Apply top inset to settings button to avoid status bar overlap
-            val settingsButton = binding.settingsButton
-            val layoutParams = settingsButton.layoutParams as androidx.constraintlayout.widget.ConstraintLayout.LayoutParams
-            layoutParams.topMargin = insets.top + 16 // 16dp base margin + status bar height
-            settingsButton.layoutParams = layoutParams
-            
-            if (FeatureFlags.LOG_TIMER_EVENTS) {
-                android.util.Log.d("VibeApp", "Applied window insets - top: ${insets.top}dp")
-            }
-            
-            windowInsets
-        }
-    }
     
     private fun showSettingsDialog() {
         try {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/background"
+    android:fitsSystemWindows="true"
     tools:context=".MainActivity">
 
     <TextView

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,9 +10,7 @@
         <item name="colorSecondaryVariant">@color/accent</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
-        <!-- Enable edge-to-edge display for proper inset handling -->
-        <item name="android:windowLayoutInDisplayCutoutMode" tools:targetApi="28">shortEdges</item>
+        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>


### PR DESCRIPTION
## Summary
• Fixed settings gear being positioned too low after PR #90 merge
• Replaced complex edge-to-edge inset handling with simple, idiomatic Android solution
• Used standard `android:fitsSystemWindows="true"` approach for status bar overlap

## Problem
PR #90 introduced a complex edge-to-edge implementation that was pushing the settings gear too low by adding the full status bar height as top margin. This made the UI look unnatural and pushed the settings button too far down from the status bar.

## Solution
Replaced the complex implementation with the standard Android approach:
- **Removed**: Complex `WindowCompat.setDecorFitsSystemWindows()` and inset listeners
- **Added**: Simple `android:fitsSystemWindows="true"` to root ConstraintLayout  
- **Reverted**: Status bar theme back to standard `colorPrimaryVariant`
- **Cleaned up**: Unnecessary imports and complex positioning code

## Changes
- **Layout**: Added `android:fitsSystemWindows="true"` to `activity_main.xml` root
- **Theme**: Reverted status bar color from transparent back to `?attr/colorPrimaryVariant`
- **MainActivity**: Removed `WindowCompat`, `ViewCompat`, and `setupSystemWindowInsets()`
- **Code Quality**: Removed 20+ lines of complex inset handling code

## Benefits
✅ **Idiomatic**: Uses standard Android layout behavior  
✅ **Simple**: One-line solution vs complex edge-to-edge handling  
✅ **Natural positioning**: Settings gear appears at appropriate distance from status bar  
✅ **Maintainable**: Follows Android documentation best practices  
✅ **Compatible**: Works across Android versions without edge cases  

## Test plan
- [x] Build passes locally
- [x] No lint issues  
- [ ] Test on Pixel 8 to verify settings gear is no longer too low
- [ ] Test on other devices to ensure no overlap with status bar
- [ ] Verify settings gear is clickable and properly positioned

## Technical Details
This follows the standard Android approach recommended in the documentation for handling status bar overlap. The `fitsSystemWindows="true"` attribute automatically handles the status bar padding without requiring manual inset calculations or edge-to-edge complexity.

**Before**: Settings gear pushed too low by status bar height + 16dp margin  
**After**: Settings gear positioned naturally below status bar using system padding

🤖 Generated with [Claude Code](https://claude.ai/code)