### PR TITLE
fix: prevent settings gear overlap with status bar using fitsSystemWi…

### DIFF
--- a/app/src/main/java/dev/broken/app/vibe/MainActivity.kt
+++ b/app/src/main/java/dev/broken/app/vibe/MainActivity.kt
@@ -270,6 +270,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
     
+    
     private fun showSettingsDialog() {
         try {
             val dialogView = LayoutInflater.from(this).inflate(R.layout.dialog_settings, null)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/background"
+    android:fitsSystemWindows="true"
     tools:context=".MainActivity">
 
     <TextView


### PR DESCRIPTION
…ndows

- Add android:fitsSystemWindows="true" to root ConstraintLayout for proper status bar handling
- Reverted from complex edge-to-edge approach to simpler, more idiomatic solution
- Removed unnecessary WindowCompat and inset listener code that pushed settings too low
- Maintained existing status bar color theme for consistency
- Uses standard Android layout behavior to avoid overlap with system UI

This provides a clean, minimal solution that follows Android best practices for handling status bar overlap without over-engineering the positioning. The settings gear will now appear properly positioned below the status bar on modern devices like Pixel 8 without being pushed too far down.

Resolves #88

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary
<!-- Describe the changes and the purpose of this PR -->


## Changes
<!-- List the specific changes made in this PR -->
- 
- 
- 

## Testing
<!-- Describe how to test these changes -->
1. 
2. 
3. 

## Screenshots (if applicable)
<!-- Add screenshots if the PR includes UI changes -->

## Additional Notes
<!-- Any other information that would be useful to reviewers -->