### PR TITLE
Add androidTest compilation to PR CI workflow

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -70,6 +70,9 @@ jobs:
      
     - name: Build Debug APK
       run: ./gradlew assembleDebug
+
+    - name: Build Android Test APK
+      run: ./gradlew assembleDebugAndroidTest
     
     - name: Generate version name
       id: version


### PR DESCRIPTION
## Problem
The current PR CI workflow only validates unit tests but not androidTest compilation. This created a gap where androidTest compilation errors (like the recent `Screenshot.CompressFormat.PNG` issue) went undetected until release workflows tried to run Firebase Test Lab.

## Solution
- Add `./gradlew assembleDebugAndroidTest` step to Android CI workflow
- Ensures androidTest code compiles correctly on every PR
- Catches compilation errors early in the development process

## Changes Made
- Added androidTest APK build step after regular APK build
- Maintains existing workflow structure and dependencies
- No impact on build performance (already building debug APK)

## Benefits
- ✅ PRs will fail if androidTest code doesn't compile
- ✅ Prevents androidTest issues from reaching release stage  
- ✅ Improves confidence in code quality before merge
- ✅ Catches errors like missing imports, API changes, etc.

## Context
This addresses the root cause analysis from the recent release workflow failure where a `CompressFormat` compilation error in androidTest code wasn't caught during PR review but failed during the release process.

🤖 Generated with [Claude Code](https://claude.ai/code)