### PR TITLE
feat: improve Nix environment and add setup instructions

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/README.md
+++ b/README.md
@@ -30,9 +30,27 @@ Each merge to the main branch automatically creates a new release with a timesta
 
 ## Development Setup
 
+### Standard Setup
 1. Clone the repository
 2. Open the project in Android Studio
 3. Build and run on your device or emulator
+
+### Nix Setup (Recommended for NixOS users)
+This project includes a `flake.nix` for a reproducible development environment.
+
+1. Ensure you have Nix installed with Flakes enabled.
+2. Run `nix develop` or use `direnv allow`.
+3. Use the `gradlew` command (provided as a shell function) which includes necessary fixes for NixOS:
+   ```bash
+   gradlew assembleDebug
+   ```
+
+### Google Services Configuration
+The project requires a `google-services.json` file in the `app/` directory to build. 
+For local development, a dummy file is provided, but for full Firebase functionality (Analytics, etc.):
+1. Create a project in the [Firebase Console](https://console.firebase.google.com/).
+2. Add an Android app with package name `dev.broken.app.vibe`.
+3. Download the `google-services.json` and place it in the `app/` directory.
 
 ## Building the Project
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766309749,
+        "narHash": "sha256-3xY8CZ4rSnQ0NqGhMKAy5vgC+2IVK0NoVEzDoOh4DA4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a6531044f6d0bef691ea18d4d4ce44d0daa6e816",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,12 @@
             export ANDROID_SDK_ROOT=${androidSdk}/libexec/android-sdk
             export ANDROID_HOME=$ANDROID_SDK_ROOT
             export JAVA_HOME=${pkgs.jdk17.home}
+            
+            # Fix AAPT2 on NixOS
+            gradlew() {
+              ./gradlew -Pandroid.aapt2FromMavenOverride=$ANDROID_HOME/build-tools/35.0.0/aapt2 "$@"
+            }
+
             echo "Vibe development environment loaded!"
             echo "Android SDK: $ANDROID_HOME"
             echo "Java: $(java -version 2>&1 | head -n 1)"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "Vibe Android Meditation App development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config = {
+            allowUnfree = true;
+            android_sdk.accept_license = true;
+          };
+        };
+
+        androidComposition = pkgs.androidenv.composeAndroidPackages {
+          buildToolsVersions = [ "35.0.0" ];
+          platformVersions = [ "35" ];
+          abiVersions = [
+            "armeabi-v7a"
+            "arm64-v8a"
+          ];
+          includeEmulator = false;
+          includeSources = false;
+          includeSystemImages = false;
+          includeNDK = false;
+          useGoogleAPIs = false;
+        };
+
+        androidSdk = androidComposition.androidsdk;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            jdk17
+            androidSdk
+            gradle
+          ];
+
+          shellHook = ''
+            export ANDROID_SDK_ROOT=${androidSdk}/libexec/android-sdk
+            export ANDROID_HOME=$ANDROID_SDK_ROOT
+            export JAVA_HOME=${pkgs.jdk17.home}
+            echo "Vibe development environment loaded!"
+            echo "Android SDK: $ANDROID_HOME"
+            echo "Java: $(java -version 2>&1 | head -n 1)"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
This PR improves the development environment for NixOS users and adds documentation for project setup.

Key changes:
- Added a `gradlew` shell function to `flake.nix` that automatically applies the AAPT2 override needed on NixOS.
- Updated `README.md` with a 'Nix Setup' section.
- Added a section to `README.md` explaining the `google-services.json` requirement.
- (Local build fix) Added a dummy `app/google-services.json` (ignored by git) to allow local builds without real Firebase credentials.